### PR TITLE
Replacing error control operator by file_exists check

### DIFF
--- a/voce-seo.php
+++ b/voce-seo.php
@@ -15,7 +15,9 @@ class VSEO {
 
 	public static function init() {
 
-		@include( dirname( __FILE__ ) . '/vendor/autoload.php' );
+		if ( true === file_exists( dirname(__FILE__) . '/vendor/autoload.php' ) ) {
+			include( dirname( __FILE__ ) . '/vendor/autoload.php' );
+		}
 
 		self::upgrade_check();
 


### PR DESCRIPTION
While the control error operator effectively prevents Warnings from being triggered, hiding the Warnings is not the best practice as it often is hiding bugs and makes the code less readable.

This commit is replacing the `@` sign in before the `include` and replaces it by more verbose `if ( file_exists() )` check.

This change reflects the recent additions to WordPress.com VIP "What we look for" documentation (all instances of this code has already been patched at the WordPress.com VIP platform).